### PR TITLE
Teams stats

### DIFF
--- a/server/controllers/strava.controller.js
+++ b/server/controllers/strava.controller.js
@@ -6,6 +6,7 @@ var https = require("https");
 var citService = require('../services/cit.service');
 var User = mongoose.model('User');
 var strava = require('strava-v3');
+var cluster = require('cluster');
 var fs = require('fs');
 
 var apiKey = "";

--- a/server/controllers/strava.controller.js
+++ b/server/controllers/strava.controller.js
@@ -45,6 +45,12 @@ if (process.env.NODE_ENV != "production") {
     callbackUrl = "localhost";
 }
 
+// The master node should update the stats in the database at set intervals and then
+// the child nodes will automatically pick up the changes
+if (cluster.isMaster) {
+    updateEveryInterval(60);
+}
+
 /**
  * List of Users
  */
@@ -261,3 +267,28 @@ function updateUser(user) {
         getStats(user);
     }
 };
+
+/**
+ * Refresh user strava data every minutes
+ */
+function updateEveryInterval(minutes) {
+
+    console.log("Begin stats refresh every " + minutes + " minutes");
+    var millis = minutes * 60 * 1000;
+
+    setInterval(function(){
+        User.find().exec(function(err, users) {
+            if (err) {
+                console.log("Data update error please try again later");
+            } else {
+                var userCount = users.length;
+                for (var i = 0; i < userCount; i++) {
+                    if (users[i].access_token) {
+                        updateUser(users[i]);
+                    }
+                }
+                console.log("All User updates complete");
+          }
+      });
+    }, millis);
+}

--- a/server/controllers/teams.controller.js
+++ b/server/controllers/teams.controller.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 var mongoose = require('mongoose');
+var cluster = require('cluster');
 var Team = mongoose.model('Team');
 var User = mongoose.model('User');
 
@@ -35,6 +36,9 @@ exports.list = function(req, res, next) {
  * All Team data
  */
 exports.all = function(req, res, next) {
+
+    // Get all the users first so we can swap in their real names.
+
     Team.find({}).exec(function(err, teams) {
         if (err) {
             res.render('error', {

--- a/server/controllers/teams.controller.js
+++ b/server/controllers/teams.controller.js
@@ -10,17 +10,38 @@ if (process.env.NODE_ENV != "production") {
     callbackUrl = "localhost";
 }
 
+// The master node should update the stats in the database at set intervals and then
+// the child nodes will automatically pick up the changes
+if (cluster.isMaster) {
+    updateEveryInterval(60);
+}
+
 /**
  * List of Team names
  */
 exports.list = function(req, res, next) {
-    Team.find({}).select('name').sort('name').exec(function(err, users) {
+    Team.find({}).select('name').sort('name').exec(function(err, teams) {
         if (err) {
             res.render('error', {
                 status: 500
             });
         } else {
-            res.jsonp(users);
+            res.jsonp(teams);
+        }
+    });
+};
+
+/**
+ * All Team data
+ */
+exports.all = function(req, res, next) {
+    Team.find({}).exec(function(err, teams) {
+        if (err) {
+            res.render('error', {
+                status: 500
+            });
+        } else {
+            res.jsonp(teams);
         }
     });
 };
@@ -37,6 +58,9 @@ exports.create = function(req, res) {
         if (!user) res.send(400, { message: 'createTeamFailedUserNotFound'});
 
         var team = new Team(req.body);
+        if (!team.members.includes(team.captain)) {
+            team.members.push(team.captain);
+        }
 
         team.save(function(err) {
             if (err) {
@@ -67,6 +91,10 @@ exports.update = function(req, res) {
             if (!team) res.send(400, { message: 'joinTeamFailed'});
             if (team == null) res.send(400, { message: 'joinTeamFailed'});
 
+            if (team.members.includes(req.body.member)) {
+                res.send(400, { message: 'joinTeamFailedAlreadyAMember'});
+            }
+
             team.members.push(req.body.member);
             team.markModified('members');
                 
@@ -81,4 +109,62 @@ exports.update = function(req, res) {
         });
     });
 };
+
+/**
+ * Refresh Team data every x minutes
+ */
+function updateEveryInterval(minutes) {
+
+    console.log("Begin Team stats refresh every " + minutes + " minutes");
+    var millis = minutes * 60 * 1000;
+
+    setInterval(function(){
+
+        User.find().exec(function(err, users) {
+            if (err) {
+                console.log("Data update error please try again later");
+            } else {
+
+                let userMap = [];
+                users.forEach(function(user) {
+                    userMap[user.username] = user;
+                });
+
+                Team.find().exec(function(err, teams) {
+
+                    teams.forEach(function(team) {
+
+                        team.activities.Walk = 0;
+                        team.activities.Run = 0;
+                        team.activities.Swim = 0;
+                        team.activities.Cycling = 0;
+                        team.activities.Rowing = 0;
+                        team.totalDistance = 0;
+
+                        team.members.forEach(function(member) {
+                            team.activities.Walk += userMap[member].totalWalk;
+                            team.activities.Run += userMap[member].totalRun;
+                            team.activities.Swim += userMap[member].totalSwim;
+                            team.activities.Cycling += userMap[member].totalCycling;
+                            team.activities.Rowing += userMap[member].totalRowing;
+
+                            team.totalDistance += userMap[member].totalDistance;
+                        });
+
+                        team.markModified('activities');
+                        team.markModified('totalDistance');
+
+                        team.save(function(err) {
+                            if (err) {
+                                console.log("Error updating team stats: " + team.name);
+                            }
+                        });
+                    });
+
+                    console.log("All Team updates complete");
+                });
+          }
+      });
+    }, millis);
+}
 

--- a/server/middlewares/addDevMiddlewares.js
+++ b/server/middlewares/addDevMiddlewares.js
@@ -37,6 +37,7 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
   // app.get('/users/addManual', users.addManual);
 
   app.get('/teams/list', teams.list);
+  app.get('/teams', teams.all);
   app.post('/teams', teams.create);
   app.put('/teams', teams.update);
 

--- a/server/middlewares/addProdMiddlewares.js
+++ b/server/middlewares/addProdMiddlewares.js
@@ -26,6 +26,7 @@ module.exports = function addProdMiddlewares(app, options) {
   // app.get('/users/addManual', users.addManual);
 
   app.get('/teams/list', teams.list);
+  app.get('/teams', teams.all);
   app.post('/teams', teams.create);
   app.put('/teams', teams.update);
 

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -31,6 +31,11 @@ var UserSchema = new Schema({
     totalCalories: Number,
     totalDuration: Number,
     totalSteps: Number,
+    totalWalk: Number,
+    totalRun: Number,
+    totalSwim: Number,
+    totalCycling: Number,
+    totalRowing: Number,
 }, {strict: false});
 
 UserSchema.statics = {

--- a/server/routes/teams.route.js
+++ b/server/routes/teams.route.js
@@ -9,6 +9,7 @@ const router = express.Router();
 module.exports = () => {
   // Team Routes
   router.get('/list', list);
+  router.get('/', all);
   router.post('/', create);
   router.put('/', update);
 


### PR DESCRIPTION
Added /teams endpoint that will return all teams data. At the moment the captain and members [] only have Capco 4 letter ID. I will modify these in a future PR to be objects i.e. { username: "abcd", name: "Joe Bloggs", level: "PC", location: "London"}