### PR TITLE
Pass Google Maps API key to webpack on app build

### DIFF
--- a/config/webpack.base.babel.js
+++ b/config/webpack.base.babel.js
@@ -74,7 +74,8 @@ module.exports = (options) => ({
     // drop any unreachable code.
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+        REACT_APP_GOOGLE_MAPS_API_KEY: JSON.stringify(process.env.REACT_APP_GOOGLE_MAPS_API_KEY)
       }
     })
   ]),


### PR DESCRIPTION
Fix google maps api key error not being received by react app. Note: REACT_APP_GOOGLE_MAPS_API_KEY env variable must be set in current environment with correct API key.