### PR TITLE
Update boolean statement for checking max team size is five members

### DIFF
--- a/server/controllers/teams.controller.js
+++ b/server/controllers/teams.controller.js
@@ -187,7 +187,7 @@ exports.create = function(req, res) {
             res.send(400, { message: 'createTeamFailedTooFewPeople'});
             return;
         }
-        if (team.members.length > maxMembers) {
+        if (team.members.length >= maxMembers) {
             console.log("Max Fail");
             res.send(400, { message: 'createTeamFailedTooManyPeople'});
             return;
@@ -236,7 +236,7 @@ exports.update = function(req, res) {
                 res.send(400, { message: 'joinTeamFailedAlreadyAMember'});
                 return;
             }
-            if (team.members.length > maxMembers) {
+            if (team.members.length >= maxMembers) {
                 res.send(400, { message: 'joinTeamFailedTooManyPeople'});
                 return;
             }


### PR DESCRIPTION
Correct boolean statement that checks team 'team.members.length' to >= from >. Limits team members to 5 rather than current 6.

This could be added to another PR that collates bug fixes from ESTR trial.